### PR TITLE
Resolve lint errors causing npm scripts to exit

### DIFF
--- a/src/app/api/anchor/route.ts
+++ b/src/app/api/anchor/route.ts
@@ -35,13 +35,15 @@ export async function POST(req: NextRequest) {
             }), { status: 200, headers: { 'content-type': 'application/json' } }));
           }
         });
-      } catch (err: any) {
-        reject(new Response(JSON.stringify({ error: err.message || String(err) }), { status: 500 }));
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        reject(new Response(JSON.stringify({ error: message }), { status: 500 }));
       }
     }).finally(async () => {
       await api.disconnect();
     });
-  } catch (e: any) {
-    return new Response(JSON.stringify({ error: e.message || String(e) }), { status: 500 });
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    return new Response(JSON.stringify({ error: message }), { status: 500 });
   }
 }

--- a/src/app/polkadot/page.tsx
+++ b/src/app/polkadot/page.tsx
@@ -48,7 +48,7 @@ export default function PolkadotConnectivity() {
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [info.endpoint]);
 
   return (
     <main className="mx-auto max-w-xl p-6 space-y-4">

--- a/src/app/verify/page.tsx
+++ b/src/app/verify/page.tsx
@@ -16,13 +16,11 @@ function useQueryHash() {
 
 export default function VerifyPage() {
   const qrHash = useQueryHash();
-  const [file, setFile] = useState<File | null>(null);
   const [calcHash, setCalcHash] = useState<string>("");
   const [status, setStatus] = useState<"idle" | "match" | "nomatch">("idle");
 
   async function onSelect(e: React.ChangeEvent<HTMLInputElement>) {
     const f = e.target.files?.[0] ?? null;
-    setFile(f || null);
     setCalcHash("");
     setStatus("idle");
     if (!f) return;


### PR DESCRIPTION
## Summary
- handle errors without `any` in API routes
- simplify health check route
- fix React effect and unused variable warnings

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68be003b66c4832b9843840f2d220f25