### PR TITLE
Fix missing @tailwindcss/postcss dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,12 @@
     "qrcode": "^1.5.4"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.12",
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.32",
     "prettier": "^3.3.3",
     "typescript": "^5.9.2",
-    "@types/qrcode": "^1.5.5"
+    "@types/qrcode": "^1.5.5",
+    "tailwindcss": "^4.1.12"
   }
 }


### PR DESCRIPTION
## Summary
- add `@tailwindcss/postcss` and `tailwindcss` to dev dependencies so PostCSS can load Tailwind plugin

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68be036f7d3c832bb2d52f2d0b0e9c41