### PR TITLE
chore: add React type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prettier": "^3.3.3",
     "typescript": "^5.9.2",
     "@types/qrcode": "^1.5.5",
-    "tailwindcss": "^4.1.12"
+    "tailwindcss": "^4.1.12",
+    "@types/react": "^19.1.12"
   }
 }


### PR DESCRIPTION
## Summary
- add @types/react as a dev dependency for React type coverage

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68be051e7240832ba890c5b06347b2dc