### PR TITLE
Add decentralized identity login page

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+
+export default function LoginPage() {
+  const [accounts, setAccounts] = useState<string[]>([]);
+  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleLogin = async () => {
+    setStatus("loading");
+    setError(null);
+    try {
+      const { web3Enable, web3Accounts } = await import(
+        "@polkadot/extension-dapp"
+      );
+      const extensions = await web3Enable("W3b Stitch");
+      if (extensions.length === 0) {
+        throw new Error("No wallet extensions found");
+      }
+      const allAccounts = await web3Accounts();
+      setAccounts(allAccounts.map((a) => a.address));
+      setStatus("idle");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setStatus("error");
+    }
+  };
+
+  return (
+    <main className="mx-auto max-w-xl p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Decentralized Identity Login</h1>
+      <button
+        onClick={handleLogin}
+        className="px-6 py-3 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold rounded-xl shadow-lg transition"
+        disabled={status === "loading"}
+      >
+        {status === "loading" ? "Connecting..." : "Login with Polkadot"}
+      </button>
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      {accounts.length > 0 && (
+        <ul className="text-sm space-y-1">
+          {accounts.map((a) => (
+            <li key={a} className="break-all">
+              {a}
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,22 +3,39 @@ export default function Home() {
     <main className="min-h-screen bg-gradient-to-b from-black via-gray-900 to-black text-white flex items-center justify-center">
       <div className="text-center px-6">
         <h1 className="text-5xl font-extrabold mb-6 tracking-tight">
-          W3b Stitch — <span className="text-indigo-400">Proof of Authenticity</span>
+          W3b Stitch —{" "}
+          <span className="text-indigo-400">Proof of Authenticity</span>
         </h1>
 
         <p className="mb-10 text-lg text-gray-300 max-w-2xl mx-auto">
-          A decentralized trust engine for verifying media, credentials, and identities.
-          Built on <span className="font-semibold">Polkadot</span> for security and interoperability.
+          A decentralized trust engine for verifying media, credentials, and
+          identities. Built on <span className="font-semibold">Polkadot</span>{" "}
+          for security and interoperability.
         </p>
 
         <div className="flex items-center justify-center gap-4 flex-wrap">
-          <a href="/polkadot" className="px-6 py-3 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold rounded-xl shadow-lg transition">
+          <a
+            href="/polkadot"
+            className="px-6 py-3 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold rounded-xl shadow-lg transition"
+          >
             🔗 Polkadot Connectivity
           </a>
-          <a href="/verify" className="px-6 py-3 bg-white hover:bg-gray-200 text-black font-semibold rounded-xl shadow-lg transition">
+          <a
+            href="/verify"
+            className="px-6 py-3 bg-white hover:bg-gray-200 text-black font-semibold rounded-xl shadow-lg transition"
+          >
             ✅ Try Verification
           </a>
-          <a href="/credential" className="px-6 py-3 bg-emerald-600 hover:bg-emerald-700 text-white font-semibold rounded-xl shadow-lg transition">
+          <a
+            href="/login"
+            className="px-6 py-3 bg-pink-600 hover:bg-pink-700 text-white font-semibold rounded-xl shadow-lg transition"
+          >
+            🔐 DID Login
+          </a>
+          <a
+            href="/credential"
+            className="px-6 py-3 bg-emerald-600 hover:bg-emerald-700 text-white font-semibold rounded-xl shadow-lg transition"
+          >
             🎓 Credential → QR
           </a>
         </div>


### PR DESCRIPTION
## Summary
- Add a dedicated Decentralized Identity login page that connects to Polkadot wallet extensions and lists user accounts
- Link to the new login page from the homepage via a "DID Login" button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be085c67a0832bac0c2e0e45cd6ad0