### PR TITLE
feat: add westend anchor endpoint

### DIFF
--- a/src/app/api/anchor/route.ts
+++ b/src/app/api/anchor/route.ts
@@ -6,38 +6,63 @@ export const runtime = 'nodejs'; // needed for WS in serverless
 
 export async function POST(req: NextRequest) {
   try {
-    const { hash } = await req.json();
-    if (!hash || !/^0x[0-9a-fA-F]{64}$/.test(hash)) {
-      return new Response(JSON.stringify({ error: 'Invalid hash, must be 0x + 64 hex chars' }), { status: 400 });
+    const { hash } = (await req.json()) as { hash?: unknown };
+    const raw = typeof hash === 'string' ? hash : '';
+    const cleaned = raw.startsWith('0x') ? raw.slice(2) : raw;
+    if (!/^[0-9a-fA-F]{64}$/.test(cleaned)) {
+      return new Response(
+        JSON.stringify({ error: 'Invalid hash, must be 64 hex chars' }),
+        { status: 400 }
+      );
     }
+    const fullHash = `0x${cleaned}`;
 
-    const provider = new WsProvider(process.env.WESTEND_WSS || 'wss://westend-rpc.polkadot.io');
+    const provider = new WsProvider(
+      process.env.WESTEND_WSS || 'wss://westend-rpc.polkadot.io'
+    );
     const api = await ApiPromise.create({ provider });
 
     const keyring = new Keyring({ type: 'sr25519' });
-    const signer = keyring.addFromUri(process.env.ANCHOR_SIGNER_URI || '//Alice');
+    const signer = keyring.addFromUri(
+      process.env.ANCHOR_SIGNER_URI || '//Alice'
+    );
 
-    const tx = api.tx.system.remark(hash);
+    const tx = api.tx.system.remarkWithEvent(fullHash);
 
     return new Promise<Response>(async (resolve, reject) => {
       try {
-        const unsub = await tx.signAndSend(signer, ({ status, txHash, dispatchError }) => {
-          if (dispatchError) {
-            unsub?.();
-            reject(new Response(JSON.stringify({ error: dispatchError.toString() }), { status: 500 }));
+        const unsub = await tx.signAndSend(
+          signer,
+          ({ status, txHash, dispatchError }) => {
+            if (dispatchError) {
+              unsub?.();
+              reject(
+                new Response(
+                  JSON.stringify({ error: dispatchError.toString() }),
+                  { status: 500 }
+                )
+              );
+            }
+            if (status.isInBlock || status.isFinalized) {
+              unsub?.();
+              resolve(
+                new Response(
+                  JSON.stringify({
+                    ok: true,
+                    txHash: txHash.toHex(),
+                    explorer: `https://westend.subscan.io/extrinsic/${txHash.toHex()}`,
+                  }),
+                  { status: 200, headers: { 'content-type': 'application/json' } }
+                )
+              );
+            }
           }
-          if (status.isInBlock || status.isFinalized) {
-            unsub?.();
-            resolve(new Response(JSON.stringify({
-              ok: true,
-              txHash: txHash.toHex(),
-              explorer: `https://westend.subscan.io/extrinsic/${txHash.toHex()}`
-            }), { status: 200, headers: { 'content-type': 'application/json' } }));
-          }
-        });
+        );
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err);
-        reject(new Response(JSON.stringify({ error: message }), { status: 500 }));
+        reject(
+          new Response(JSON.stringify({ error: message }), { status: 500 })
+        );
       }
     }).finally(async () => {
       await api.disconnect();

--- a/src/app/api/credential/route.ts
+++ b/src/app/api/credential/route.ts
@@ -21,36 +21,31 @@ export async function POST(req: NextRequest): Promise<NextResponse<AnchorRespons
       return NextResponse.json({ ok: false, error: "hash required" }, { status: 400 });
     }
 
-    const endpoint = process.env.ANCHOR_ENDPOINT;
-    if (endpoint) {
-      const r = await fetch(endpoint, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ hash, filename }),
-        cache: "no-store",
-      });
+    const endpoint =
+      process.env.ANCHOR_ENDPOINT ?? new URL("/api/anchor", req.url).toString();
 
-      if (!r.ok) {
-        const detail = await r.text();
-        return NextResponse.json({ ok: false, error: "anchor failed", detail }, { status: 502 });
-      }
+    const r = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ hash, filename }),
+      cache: "no-store",
+    });
 
-      const data = (await r.json()) as Record<string, unknown>;
-      return NextResponse.json({
-        ok: true,
-        hash,
-        filename: filename || null,
-        anchored: true,
-        receipt: data,
-      });
+    if (!r.ok) {
+      const detail = await r.text();
+      return NextResponse.json(
+        { ok: false, error: "anchor failed", detail },
+        { status: 502 }
+      );
     }
 
+    const data = (await r.json()) as Record<string, unknown>;
     return NextResponse.json({
       ok: true,
       hash,
       filename: filename || null,
-      anchored: false,
-      receipt: { note: "No ANCHOR_ENDPOINT configured; returning local receipt only." },
+      anchored: true,
+      receipt: data,
     });
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : "unknown error";


### PR DESCRIPTION
## Summary
- add `/api/anchor` endpoint anchoring hashes to Westend via remarkWithEvent
- use `/api/anchor` from credential API for automatic on-chain anchoring

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68be0ac319c4832b93388054ff76a85b