### PR TITLE
feat: add solana connectivity page

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "@polkadot/extension-dapp": "^0.61.7",
-    "qrcode": "^1.5.4"
+    "qrcode": "^1.5.4",
+    "@solana/web3.js": "^1.95.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.12",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,6 +21,12 @@ export default function Home() {
             🔗 Polkadot Connectivity
           </a>
           <a
+            href="/solana"
+            className="px-6 py-3 bg-violet-600 hover:bg-violet-700 text-white font-semibold rounded-xl shadow-lg transition"
+          >
+            🟣 Solana Connectivity
+          </a>
+          <a
             href="/verify"
             className="px-6 py-3 bg-white hover:bg-gray-200 text-black font-semibold rounded-xl shadow-lg transition"
           >

--- a/src/app/solana/page.tsx
+++ b/src/app/solana/page.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function SolanaConnectivity() {
+  const [status, setStatus] = useState<"idle" | "connecting" | "ok" | "error">("idle");
+  const [info, setInfo] = useState<{
+    endpoint: string;
+    slot?: number;
+    version?: string;
+    error?: string;
+  }>({
+    endpoint: "https://api.devnet.solana.com",
+  });
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      setStatus("connecting");
+      try {
+        const { Connection } = await import("@solana/web3.js");
+        const connection = new Connection(info.endpoint);
+        const [slot, version] = await Promise.all([
+          connection.getSlot(),
+          connection.getVersion(),
+        ]);
+        if (!mounted) return;
+        setInfo((p) => ({
+          ...p,
+          slot,
+          version: version["solana-core"],
+        }));
+        setStatus("ok");
+      } catch (e) {
+        if (!mounted) return;
+        setInfo((p) => ({
+          ...p,
+          error: e instanceof Error ? e.message : String(e),
+        }));
+        setStatus("error");
+      }
+    })();
+
+    return () => {
+      mounted = false;
+    };
+  }, [info.endpoint]);
+
+  return (
+    <main className="mx-auto max-w-xl p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Solana Connectivity (Devnet)</h1>
+      <p className="text-sm text-gray-400">
+        Endpoint: <code>{info.endpoint}</code>
+      </p>
+
+      {status === "connecting" && <p>Connecting…</p>}
+
+      {status === "ok" && (
+        <ul className="text-sm space-y-1">
+          <li>Slot: {info.slot}</li>
+          <li>Version: {info.version}</li>
+        </ul>
+      )}
+
+      {status === "error" && (
+        <p className="text-red-500 text-sm">Failed: {info.error}</p>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add devnet connectivity page for Solana
- link Solana page from home screen
- include @solana/web3.js dependency

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Cannot find module '@solana/web3.js')*
- `npm install @solana/web3.js --no-package-lock` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@solana%2fweb3.js)*

------
https://chatgpt.com/codex/tasks/task_e_68be253c5168832b83d7289d4ecafd75