### PR TITLE
feat: add back navigation and chain indicator

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import BackButton from "../components/BackButton";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -13,7 +14,8 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="antialiased">
+      <body className="antialiased relative">
+        <BackButton />
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,11 @@
+import ChainIndicator from "../components/ChainIndicator";
+
 export default function Home() {
   return (
-    <main className="min-h-screen bg-gradient-to-b from-black via-gray-900 to-black text-white flex items-center justify-center">
+    <main className="relative min-h-screen bg-gradient-to-b from-black via-gray-900 to-black text-white flex items-center justify-center">
+      <div className="absolute top-4 right-4">
+        <ChainIndicator />
+      </div>
       <div className="text-center px-6">
         <h1 className="text-5xl font-extrabold mb-6 tracking-tight">
           W3b Stitch —{" "}

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useRouter, usePathname } from "next/navigation";
+
+export default function BackButton() {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  if (pathname === "/") return null;
+
+  return (
+    <button
+      onClick={() => router.back()}
+      className="absolute top-4 left-4 text-xl text-white"
+      aria-label="Go back"
+    >
+      ←
+    </button>
+  );
+}

--- a/src/components/ChainIndicator.tsx
+++ b/src/components/ChainIndicator.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function ChainIndicator() {
+  const [chain, setChain] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const { ApiPromise, WsProvider } = await import("@polkadot/api");
+        const provider = new WsProvider("wss://westend-rpc.polkadot.io");
+        const api = await ApiPromise.create({ provider });
+        const chainName = await api.rpc.system.chain();
+        if (mounted) setChain(chainName.toString());
+        await api.disconnect();
+      } catch (e) {
+        if (mounted) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  if (error) {
+    return <span className="text-sm text-red-500">Not connected</span>;
+  }
+
+  return (
+    <span className="text-sm">{chain ? `Connected: ${chain}` : "Connecting..."}</span>
+  );
+}


### PR DESCRIPTION
## Summary
- add global back button for navigation
- show active chain connection on home page

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bebf42d6a8832bab35b62a8fc97c3c