### PR TITLE
Add Solflare wallet connect and back navigation

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import BackButton from "../components/BackButton";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,6 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <BackButton />
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,6 +15,9 @@ export default function Home() {
           <a href="/polkadot" className="px-6 py-3 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold rounded-xl shadow-lg transition">
             🔗 Polkadot Connectivity
           </a>
+          <a href="/solana" className="px-6 py-3 bg-purple-600 hover:bg-purple-700 text-white font-semibold rounded-xl shadow-lg transition">
+            🔥 Solana Connectivity
+          </a>
           <a href="/verify" className="px-6 py-3 bg-white hover:bg-gray-200 text-black font-semibold rounded-xl shadow-lg transition">
             ✅ Try Verification
           </a>

--- a/src/app/solana/page.tsx
+++ b/src/app/solana/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+
+export default function SolanaPage() {
+  const [address, setAddress] = useState<string | null>(null);
+  const [error, setError] = useState<string>("");
+
+  interface SolflareWallet {
+    isSolflare?: boolean;
+    connect: () => Promise<{ publicKey: { toString(): string } } | void>;
+    publicKey?: { toString(): string };
+  }
+
+  interface SolflareWindow extends Window {
+    solflare?: SolflareWallet;
+    solana?: SolflareWallet;
+  }
+
+  async function connect() {
+    try {
+      setError("");
+      const provider =
+        (window as SolflareWindow).solflare ??
+        (window as SolflareWindow).solana;
+      if (!provider || !provider.isSolflare) {
+        setError("No Solflare wallet found.");
+        return;
+      }
+      const resp = await provider.connect();
+      const pubkey = (resp?.publicKey || provider.publicKey)?.toString();
+      setAddress(pubkey);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setError(msg);
+    }
+  }
+
+  return (
+    <main className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Solana Connectivity</h1>
+      <button
+        onClick={connect}
+        disabled={!!address}
+        className="rounded-xl px-4 py-2 shadow border text-sm disabled:opacity-50"
+      >
+        {address ? `Connected: ${address.slice(0, 4)}…${address.slice(-4)}` : "Connect Solflare"}
+      </button>
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+    </main>
+  );
+}

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+
+export default function BackButton() {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  if (pathname === "/") return null;
+
+  return (
+    <button
+      onClick={() => router.back()}
+      className="fixed top-4 left-4 text-sm text-gray-600 hover:text-black"
+    >
+      ← Back
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add global back button to navigate to previous page
- add Solflare wallet connectivity page and home link

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bec6874fd4832b95d679f5a618238d