### PR TITLE
fix npm exit and update colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "lint": "next lint",
-    "fmt": "prettier --write ."
+    "fmt": "prettier --write .",
+    "test": "echo 'No tests specified' && exit 0"
   },
   "dependencies": {
     "@polkadot/api": "^16.4.6",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,8 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #87ceeb;
+  --foreground: #808080;
 }
 
 @theme inline {
@@ -12,8 +12,8 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --background: #1e3a8a;
+    --foreground: #d1d5db;
   }
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@ import ChainIndicator from "../components/ChainIndicator";
 
 export default function Home() {
   return (
-    <main className="relative min-h-screen bg-gradient-to-b from-black via-gray-900 to-black text-white flex items-center justify-center">
+    <main className="relative min-h-screen bg-gradient-to-b from-sky-400 via-sky-200 to-gray-100 text-gray-800 flex items-center justify-center">
       <div className="absolute top-4 right-4">
         <ChainIndicator />
       </div>


### PR DESCRIPTION
## Summary
- add default npm test script to prevent exit errors
- switch global theme to sky blue background and gray text
- adjust home page gradient to sky blue and gray palette

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build` *(fails: Can't resolve '@solana/web3.js')*

------
https://chatgpt.com/codex/tasks/task_e_68becb722fc4832bb29887935d516544