### PR TITLE
feat: improve solana and anchor data

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -87,9 +87,12 @@ export default function LoginPage() {
         const allAccounts = await web3Accounts();
         setAccounts(allAccounts.map((a) => a.address));
       } else {
-        const provider = (
-          window as unknown as { solana?: SolanaProvider }
-        ).solana;
+        const w =
+          window as unknown as {
+            solana?: SolanaProvider;
+            solflare?: SolanaProvider;
+          };
+        const provider = w.solana ?? w.solflare;
         if (!provider) {
           throw new Error("No Solana wallet found");
         }


### PR DESCRIPTION
## Summary
- support Solflare provider for Solana login
- display on-chain payload and timestamp after anchoring

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bece34dac4832bbfa5028a4552dcff