### PR TITLE
feat: anchor via wallet extension

### DIFF
--- a/src/app/credential/page.tsx
+++ b/src/app/credential/page.tsx
@@ -16,6 +16,7 @@ export default function CredentialPage() {
   const [receipt, setReceipt] = useState<AnchorReceipt | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>("");
+  const [status, setStatus] = useState("");
 
   async function onSelect(e: React.ChangeEvent<HTMLInputElement>) {
     setError("");
@@ -29,38 +30,92 @@ export default function CredentialPage() {
     setHash(h);
   }
 
+  function toHexFromUtf8(s: string) {
+    const bytes = new TextEncoder().encode(s);
+    let hex = "0x";
+    for (const b of bytes) hex += b.toString(16).padStart(2, "0");
+    return hex;
+  }
+
   async function onAnchor() {
     if (!file || !hash) return;
     setLoading(true);
     setError("");
+    setStatus("Connecting wallet…");
     try {
-      const r = await fetch("/api/credential", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ hash, filename: file.name }),
-      });
-      const data = (await r.json()) as {
-        ok?: boolean;
-        receipt?: AnchorReceipt;
-        error?: string;
-      };
-      if (!r.ok || !data?.ok) {
-        setError(data?.error ?? "Failed to anchor");
-        setLoading(false);
-        return;
-      }
-      setReceipt(data.receipt ?? null);
+      const [
+        { web3Enable, web3Accounts, web3FromAddress },
+        { ApiPromise, WsProvider },
+      ] = await Promise.all([
+        import("@polkadot/extension-dapp"),
+        import("@polkadot/api"),
+      ]);
 
-      // dynamic import avoids SSR hiccups
-      const QRCode = (await import("qrcode")).default;
-      const verifyUrl = `${window.location.origin}/verify?hash=${encodeURIComponent(hash)}`;
-      const png = await QRCode.toDataURL(verifyUrl, { margin: 1, width: 280 });
-      setQr(png);
+      await web3Enable("W3b Stitch");
+      const accounts = await web3Accounts();
+      if (!accounts.length)
+        throw new Error("No Polkadot/SubWallet accounts found.");
+      const address = accounts[0].address;
+
+      setStatus("Connecting to chain…");
+      const api = await ApiPromise.create({
+        provider: new WsProvider("wss://westend-rpc.polkadot.io"),
+      });
+      const injector = await web3FromAddress(address);
+
+      const payload = {
+        v: "w3bstitch.anchor",
+        alg: "sha256",
+        hash,
+        filename: file.name,
+        ts: new Date().toISOString(),
+      };
+      const hexPayload = toHexFromUtf8(JSON.stringify(payload));
+      const tx = api.tx.system.remarkWithEvent(hexPayload);
+
+      setStatus("Awaiting wallet confirmation…");
+      await new Promise<void>(async (resolve, reject) => {
+        const unsub = await tx.signAndSend(
+          address,
+          { signer: injector.signer, nonce: -1 },
+          async ({ status, dispatchError, txHash }) => {
+            if (dispatchError) {
+              unsub();
+              reject(new Error(dispatchError.toString()));
+              return;
+            }
+            if (status.isInBlock) {
+              setStatus("Included in block");
+              const txh = txHash.toHex();
+              setReceipt({
+                ok: true,
+                txHash: txh,
+                explorer: `https://westend.subscan.io/extrinsic/${txh}`,
+              });
+
+              const QRCode = (await import("qrcode")).default;
+              const verifyUrl = `${window.location.origin}/verify?hash=${encodeURIComponent(hash)}`;
+              const png = await QRCode.toDataURL(verifyUrl, {
+                margin: 1,
+                width: 280,
+              });
+              setQr(png);
+            }
+            if (status.isFinalized) {
+              setStatus("Finalized");
+              unsub();
+              resolve();
+            }
+          },
+        );
+      });
+      await api.disconnect();
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : "Unknown error";
       setError(msg);
     } finally {
       setLoading(false);
+      setStatus("");
     }
   }
 
@@ -69,7 +124,9 @@ export default function CredentialPage() {
       <h1 className="text-2xl font-bold">Credential → QR Verification</h1>
 
       <div className="space-y-2">
-        <label className="block text-sm font-medium">Upload credential (PDF/Image)</label>
+        <label className="block text-sm font-medium">
+          Upload credential (PDF/Image)
+        </label>
         <input type="file" onChange={onSelect} className="block w-full" />
         {hash && (
           <p className="text-xs break-all">
@@ -87,14 +144,25 @@ export default function CredentialPage() {
       </button>
 
       {error && <p className="text-red-600 text-sm">{error}</p>}
+      {status && !error && <p className="text-sm">{status}</p>}
 
       {qr && (
         <section className="space-y-3">
           <h2 className="text-lg font-semibold">QR Code (scan to verify)</h2>
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={qr} alt="Verification QR" className="border rounded-xl p-2" />
+          <img
+            src={qr}
+            alt="Verification QR"
+            className="border rounded-xl p-2"
+          />
           <p className="text-sm">
-            Or open: <a className="underline" href={`/verify?hash=${encodeURIComponent(hash)}`}>/verify?hash=…</a>
+            Or open:{" "}
+            <a
+              className="underline"
+              href={`/verify?hash=${encodeURIComponent(hash)}`}
+            >
+              /verify?hash=…
+            </a>
           </p>
         </section>
       )}
@@ -118,11 +186,10 @@ export default function CredentialPage() {
             )}
           </p>
           <pre className="text-xs bg-gray-100 p-3 rounded-xl overflow-auto">
-{JSON.stringify(receipt, null, 2)}
+            {JSON.stringify(receipt, null, 2)}
           </pre>
         </section>
       )}
     </main>
   );
 }
-

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import "./globals.css";
 import BackButton from "../components/BackButton";
 
-
 export const metadata: Metadata = {
   title: "W3b Stitch- Trust Engine",
   description: "Decentralized trust engine",
@@ -15,7 +14,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-
+      <body>
         <BackButton />
         {children}
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,7 +24,10 @@ export default function Home() {
           >
             🔐 Chain Picker Login
           </a>
-
+          <a
+            href="/verify"
+            className="px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-xl shadow-lg transition"
+          >
             ✅ Try Verification
           </a>
           <a

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -1,1 +1,15 @@
+"use client";
 
+import { useRouter } from "next/navigation";
+
+export default function BackButton() {
+  const router = useRouter();
+  return (
+    <button
+      onClick={() => router.back()}
+      className="absolute top-4 left-4 px-3 py-1 border rounded"
+    >
+      ← Back
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- anchor credential hashes via Polkadot wallet and show receipt
- fix layout and landing page markup
- add simple BackButton component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf0486fa20832b971bc416764664c8