### PR TITLE
Handle anchor confirmation and improve Solflare reconnection

### DIFF
--- a/src/app/api/anchor/route.ts
+++ b/src/app/api/anchor/route.ts
@@ -1,47 +1,54 @@
 // app or src/app /api/anchor/route.ts
-import { NextRequest } from 'next/server';
-import { ApiPromise, WsProvider, Keyring } from '@polkadot/api';
+import { NextRequest } from "next/server";
+import { ApiPromise, WsProvider, Keyring } from "@polkadot/api";
 
-export const runtime = 'nodejs'; // needed for WS in serverless
+export const runtime = "nodejs"; // needed for WS in serverless
 
 export async function POST(req: NextRequest) {
   try {
     const { hash } = (await req.json()) as { hash?: unknown };
-    const raw = typeof hash === 'string' ? hash : '';
-    const cleaned = raw.startsWith('0x') ? raw.slice(2) : raw;
+    const raw = typeof hash === "string" ? hash : "";
+    const cleaned = raw.startsWith("0x") ? raw.slice(2) : raw;
     if (!/^[0-9a-fA-F]{64}$/.test(cleaned)) {
       return new Response(
-        JSON.stringify({ error: 'Invalid hash, must be 64 hex chars' }),
-        { status: 400 }
+        JSON.stringify({ error: "Invalid hash, must be 64 hex chars" }),
+        { status: 400 },
       );
     }
     const fullHash = `0x${cleaned}`;
 
     const provider = new WsProvider(
-      process.env.WESTEND_WSS || 'wss://westend-rpc.polkadot.io'
+      process.env.WESTEND_WSS || "wss://westend-rpc.polkadot.io",
     );
     const api = await ApiPromise.create({ provider });
 
-    const keyring = new Keyring({ type: 'sr25519' });
+    const keyring = new Keyring({ type: "sr25519" });
     const signer = keyring.addFromUri(
-      process.env.ANCHOR_SIGNER_URI || '//Alice'
+      process.env.ANCHOR_SIGNER_URI || "//Alice",
     );
 
     const tx = api.tx.system.remarkWithEvent(fullHash);
 
-    return new Promise<Response>(async (resolve, reject) => {
+    return new Promise<Response>(async (resolve) => {
       try {
         const unsub = await tx.signAndSend(
           signer,
           ({ status, txHash, dispatchError }) => {
             if (dispatchError) {
               unsub?.();
-              reject(
+              resolve(
                 new Response(
-                  JSON.stringify({ error: dispatchError.toString() }),
-                  { status: 500 }
-                )
+                  JSON.stringify({
+                    ok: false,
+                    error: dispatchError.toString(),
+                  }),
+                  {
+                    status: 500,
+                    headers: { "content-type": "application/json" },
+                  },
+                ),
               );
+              return;
             }
             if (status.isInBlock || status.isFinalized) {
               unsub?.();
@@ -52,16 +59,22 @@ export async function POST(req: NextRequest) {
                     txHash: txHash.toHex(),
                     explorer: `https://westend.subscan.io/extrinsic/${txHash.toHex()}`,
                   }),
-                  { status: 200, headers: { 'content-type': 'application/json' } }
-                )
+                  {
+                    status: 200,
+                    headers: { "content-type": "application/json" },
+                  },
+                ),
               );
             }
-          }
+          },
         );
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err);
-        reject(
-          new Response(JSON.stringify({ error: message }), { status: 500 })
+        resolve(
+          new Response(JSON.stringify({ ok: false, error: message }), {
+            status: 500,
+            headers: { "content-type": "application/json" },
+          }),
         );
       }
     }).finally(async () => {

--- a/src/app/solana/page.tsx
+++ b/src/app/solana/page.tsx
@@ -33,8 +33,10 @@ export default function SolanaPage() {
         setError("No Solflare wallet found.");
         return;
       }
-      const resp = await provider.connect();
-      const pubkey = (resp?.publicKey || provider.publicKey)?.toString();
+      if (!provider.publicKey) {
+        await provider.connect();
+      }
+      const pubkey = provider.publicKey?.toString();
       if (pubkey) {
         setAddress(pubkey);
         localStorage.setItem("solanaAddress", pubkey);
@@ -47,8 +49,7 @@ export default function SolanaPage() {
 
   function logout() {
     const provider =
-      (window as SolflareWindow).solflare ??
-      (window as SolflareWindow).solana;
+      (window as SolflareWindow).solflare ?? (window as SolflareWindow).solana;
     try {
       provider?.disconnect?.();
     } catch {


### PR DESCRIPTION
## Summary
- ensure anchor API returns explicit success/error JSON instead of promise rejection
- surface failure details in credential endpoint based on anchor API response
- reconnect Solflare wallet when already connected

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf0678d020832b804b5e15ccb8ba29