### PR TITLE
feat: detect any solana wallet extension

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,10 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-
-interface SolanaProvider {
-  connect: () => Promise<{ publicKey: { toString(): string } }>;
-}
+import { getSolanaProvider } from "@/lib/solana-provider";
 
 type Chain = "westend" | "solana";
 
@@ -63,10 +60,7 @@ export default function LoginPage() {
         await api.disconnect();
       } else {
         const { Connection } = await import("@solana/web3.js");
-        const provider =
-          (window as unknown as { solana?: SolanaProvider }).solana ??
-          (window as unknown as { phantom?: { solana?: SolanaProvider } })
-            .phantom?.solana;
+        const provider = getSolanaProvider();
         if (!provider) {
           throw new Error("No Solana wallet found");
         }

--- a/src/app/solana/page.tsx
+++ b/src/app/solana/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { getSolanaProvider } from "@/lib/solana-provider";
 
 export default function SolanaPage() {
   const [address, setAddress] = useState<string | null>(null);
@@ -11,26 +12,12 @@ export default function SolanaPage() {
     if (saved) setAddress(saved);
   }, []);
 
-  interface SolflareWallet {
-    isSolflare?: boolean;
-    connect: () => Promise<{ publicKey: { toString(): string } } | void>;
-    disconnect?: () => Promise<void> | void;
-    publicKey?: { toString(): string };
-  }
-
-  interface SolflareWindow extends Window {
-    solflare?: SolflareWallet;
-    solana?: SolflareWallet;
-  }
-
   async function connect() {
     try {
       setError("");
-      const provider =
-        (window as SolflareWindow).solflare ??
-        (window as SolflareWindow).solana;
+      const provider = getSolanaProvider();
       if (!provider) {
-        setError("No Solflare wallet found.");
+        setError("No Solana wallet found.");
         return;
       }
       if (!provider.publicKey) {
@@ -48,8 +35,7 @@ export default function SolanaPage() {
   }
 
   function logout() {
-    const provider =
-      (window as SolflareWindow).solflare ?? (window as SolflareWindow).solana;
+    const provider = getSolanaProvider();
     try {
       provider?.disconnect?.();
     } catch {
@@ -79,7 +65,7 @@ export default function SolanaPage() {
           onClick={connect}
           className="rounded-xl px-4 py-2 shadow border text-sm"
         >
-          Connect Solflare
+          Connect Solana Wallet
         </button>
       )}
       {error && <p className="text-red-600 text-sm">{error}</p>}

--- a/src/lib/solana-provider.ts
+++ b/src/lib/solana-provider.ts
@@ -1,0 +1,29 @@
+export interface SolanaProvider {
+  connect: () => Promise<{ publicKey: { toString(): string } }>;
+  disconnect?: () => Promise<void> | void;
+  publicKey?: { toString(): string };
+}
+
+export function getSolanaProvider(): SolanaProvider | null {
+  const w = window as unknown as Record<string, unknown>;
+  const direct = w.solana as unknown;
+  if (typeof direct === "object" && direct && "connect" in direct) {
+    return direct as SolanaProvider;
+  }
+  for (const key of Object.keys(w)) {
+    const value = w[key];
+    if (typeof value !== "object" || !value) continue;
+    const maybeSolana = (value as Record<string, unknown>).solana;
+    if (
+      typeof maybeSolana === "object" &&
+      maybeSolana &&
+      "connect" in maybeSolana
+    ) {
+      return maybeSolana as SolanaProvider;
+    }
+    if ("connect" in value && "publicKey" in value) {
+      return value as SolanaProvider;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- detect Solana wallet providers from any extension
- use generic provider detection on login and Solana pages

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf0850ffa0832b9a925fb403c34f71