### PR TITLE
Fix Solana login and anchor API, add credential preview

### DIFF
--- a/src/app/api/anchor/route.ts
+++ b/src/app/api/anchor/route.ts
@@ -33,7 +33,8 @@ export async function POST(req: NextRequest) {
       try {
         const unsub = await tx.signAndSend(
           signer,
-          ({ status, txHash, dispatchError }) => {
+          ({ status, dispatchError }) => {
+            const txHash = tx.hash.toHex();
             if (dispatchError) {
               unsub?.();
               resolve(
@@ -51,13 +52,18 @@ export async function POST(req: NextRequest) {
               return;
             }
             if (status.isInBlock || status.isFinalized) {
+              const blockHash = (status.isInBlock
+                ? status.asInBlock
+                : status.asFinalized
+              ).toHex();
               unsub?.();
               resolve(
                 new Response(
                   JSON.stringify({
                     ok: true,
-                    txHash: txHash.toHex(),
-                    explorer: `https://westend.subscan.io/extrinsic/${txHash.toHex()}`,
+                    txHash,
+                    blockHash,
+                    explorer: `https://westend.subscan.io/extrinsic/${txHash}`,
                   }),
                   {
                     status: 200,

--- a/src/app/credential/page.tsx
+++ b/src/app/credential/page.tsx
@@ -1,6 +1,6 @@
 ﻿"use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { fileToSha256Hex } from "../../../lib/hash";
 
 interface AnchorReceipt {
@@ -17,6 +17,7 @@ export default function CredentialPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>("");
   const [status, setStatus] = useState("");
+  const [preview, setPreview] = useState<string | null>(null);
 
   async function onSelect(e: React.ChangeEvent<HTMLInputElement>) {
     setError("");
@@ -25,10 +26,18 @@ export default function CredentialPage() {
     setHash("");
     const f = e.target.files?.[0] ?? null;
     setFile(f || null);
+    if (preview) URL.revokeObjectURL(preview);
+    setPreview(f ? URL.createObjectURL(f) : null);
     if (!f) return;
     const h = await fileToSha256Hex(f);
     setHash(h);
   }
+
+  useEffect(() => {
+    return () => {
+      if (preview) URL.revokeObjectURL(preview);
+    };
+  }, [preview]);
 
   function toHexFromUtf8(s: string) {
     const bytes = new TextEncoder().encode(s);
@@ -134,6 +143,18 @@ export default function CredentialPage() {
           </p>
         )}
       </div>
+
+      {preview && (
+        <section className="space-y-2">
+          <h2 className="text-lg font-semibold">Selected Image</h2>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={preview}
+            alt="Selected file preview"
+            className="border rounded-xl max-h-60"
+          />
+        </section>
+      )}
 
       <button
         onClick={onAnchor}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useState } from "react";
 
 interface SolanaProvider {
-  connect: () => Promise<{ publicKey: { toString(): string } }>;
+  connect: () => Promise<{ publicKey: { toString(): string } } | void>;
+  publicKey?: { toString(): string };
 }
 
 type Chain = "westend" | "solana";
@@ -71,16 +72,20 @@ export default function LoginPage() {
           throw new Error("No Solana wallet found");
         }
         const connection = new Connection("https://api.devnet.solana.com");
-        const [slot, version, resp] = await Promise.all([
+        const [slot, version] = await Promise.all([
           connection.getSlot(),
           connection.getVersion(),
-          provider.connect(),
         ]);
+        await provider.connect();
+        const pubkey = provider.publicKey?.toString();
+        if (!pubkey) {
+          throw new Error("Failed to retrieve public key");
+        }
         setConnInfo({
           slot,
           version: version["solana-core"],
         });
-        setAccounts([resp.publicKey.toString()]);
+        setAccounts([pubkey]);
       }
       setStatus("idle");
     } catch (e) {


### PR DESCRIPTION
## Summary
- handle Solana providers that don't return a value from `connect` to avoid `toString` errors
- derive transaction and block hashes in the anchor API for reliable receipts
- show selected credential image preview and clean up object URLs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf0a55c048832b9be2ee6c1e07fb33