### PR TITLE
Remove heavy Solana web3 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "@polkadot/extension-dapp": "^0.61.7",
-    "qrcode": "^1.5.4",
-    "@solana/web3.js": "^1.95.4"
+    "qrcode": "^1.5.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.12",

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { Connection } from "@/lib/solana";
 
 interface SolanaProvider {
   connect: () => Promise<{ publicKey: { toString(): string } }>;
@@ -62,7 +63,6 @@ export default function LoginPage() {
         setAccounts(allAccounts.map((a) => a.address));
         await api.disconnect();
       } else {
-        const { Connection } = await import("@solana/web3.js");
         const provider =
           (window as unknown as { solana?: SolanaProvider }).solana ??
           (window as unknown as { phantom?: { solana?: SolanaProvider } })

--- a/src/lib/solana.ts
+++ b/src/lib/solana.ts
@@ -1,0 +1,24 @@
+export class Connection {
+  constructor(private readonly endpoint: string) {}
+
+  private async rpc<T>(method: string, params: unknown[] = []): Promise<T> {
+    const resp = await fetch(this.endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    });
+    const json = await resp.json();
+    if (json.error) {
+      throw new Error(json.error.message ?? "RPC Error");
+    }
+    return json.result as T;
+  }
+
+  getSlot(): Promise<number> {
+    return this.rpc<number>("getSlot");
+  }
+
+  getVersion(): Promise<{ "solana-core": string }> {
+    return this.rpc<{ "solana-core": string }>("getVersion");
+  }
+}

--- a/src/types/solana-web3.d.ts
+++ b/src/types/solana-web3.d.ts
@@ -1,7 +1,0 @@
-declare module "@solana/web3.js" {
-  export class Connection {
-    constructor(endpoint: string);
-    getSlot(): Promise<number>;
-    getVersion(): Promise<{ "solana-core": string }>;
-  }
-}


### PR DESCRIPTION
## Summary
- replace @solana/web3.js with lightweight fetch-based RPC client
- switch login page to use new Connection class
- drop unused solana-web3 types and dependency entry

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf0f2def7c832b963b7cb77fafa9ef