### PR TITLE
Use DID to determine chain info

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ export default function Home() {
   return (
     <main className="relative min-h-screen bg-gradient-to-b from-black via-gray-900 to-black text-white flex items-center justify-center">
       <div className="absolute top-4 right-4">
-        <ChainIndicator />
+        <ChainIndicator did="did:polkadot:westend" />
       </div>
       <div className="text-center px-6">
         <h1 className="text-5xl font-extrabold mb-6 tracking-tight">

--- a/src/components/ChainIndicator.tsx
+++ b/src/components/ChainIndicator.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { chainFromDid } from "@/lib/did";
 
-export default function ChainIndicator() {
+export default function ChainIndicator({ did }: { did: string }) {
   const [chain, setChain] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -10,12 +11,8 @@ export default function ChainIndicator() {
     let mounted = true;
     (async () => {
       try {
-        const { ApiPromise, WsProvider } = await import("@polkadot/api");
-        const provider = new WsProvider("wss://westend-rpc.polkadot.io");
-        const api = await ApiPromise.create({ provider });
-        const chainName = await api.rpc.system.chain();
-        if (mounted) setChain(chainName.toString());
-        await api.disconnect();
+        const chainName = await chainFromDid(did);
+        if (mounted) setChain(chainName);
       } catch (e) {
         if (mounted) setError(e instanceof Error ? e.message : String(e));
       }
@@ -23,13 +20,15 @@ export default function ChainIndicator() {
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [did]);
 
   if (error) {
     return <span className="text-sm text-red-500">Not connected</span>;
   }
 
   return (
-    <span className="text-sm">{chain ? `Connected: ${chain}` : "Connecting..."}</span>
+    <span className="text-sm">
+      {chain ? `Connected: ${chain}` : "Connecting..."}
+    </span>
   );
 }

--- a/src/lib/did.ts
+++ b/src/lib/did.ts
@@ -1,0 +1,25 @@
+import { ApiPromise, WsProvider } from "@polkadot/api";
+
+const ENDPOINTS: Record<string, string> = {
+  polkadot: "wss://rpc.polkadot.io",
+  kusama: "wss://kusama-rpc.polkadot.io",
+  westend: "wss://westend-rpc.polkadot.io",
+};
+
+export async function chainFromDid(did: string): Promise<string> {
+  const match = did.match(/^did:polkadot:([^:]+)$/);
+  if (!match) {
+    throw new Error("Unsupported DID format");
+  }
+  const network = match[1];
+  const endpoint = ENDPOINTS[network];
+  if (!endpoint) {
+    throw new Error(`Unsupported network: ${network}`);
+  }
+
+  const provider = new WsProvider(endpoint);
+  const api = await ApiPromise.create({ provider });
+  const chain = await api.rpc.system.chain();
+  await api.disconnect();
+  return chain.toString();
+}


### PR DESCRIPTION
## Summary
- add helper to derive chain endpoint from a DID and fetch the chain name
- use DID-driven chain lookup in `ChainIndicator`
- pass `did:polkadot:westend` to `ChainIndicator` on the home page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf11235d98832b94909e7d5d86bae5