### PR TITLE
Include transaction receipt & status in credential QR

### DIFF
--- a/src/app/verify/page.tsx
+++ b/src/app/verify/page.tsx
@@ -18,6 +18,7 @@ function useQueryParam(key: string) {
 export default function VerifyPage() {
   const qrHash = useQueryParam("hash");
   const qrDid = useQueryParam("did");
+  const qrTx = useQueryParam("tx");
   const { did } = useDid();
   const [calcHash, setCalcHash] = useState<string>("");
   const [status, setStatus] = useState<"idle" | "match" | "nomatch">("idle");
@@ -60,6 +61,20 @@ export default function VerifyPage() {
           {qrHash || "(none in URL)"}
         </p>
         <p className="text-sm">DID: {qrDid || "(none)"}</p>
+        <p className="text-sm">
+          Tx:{" "}
+          {qrTx ? (
+            <a
+              className="underline"
+              href={`https://westend.subscan.io/extrinsic/${qrTx}`}
+              target="_blank"
+            >
+              {qrTx}
+            </a>
+          ) : (
+            "(none)"
+          )}
+        </p>
         {did && qrDid && did !== qrDid && (
           <p className="text-red-600 text-xs">Logged-in DID mismatch</p>
         )}


### PR DESCRIPTION
## Summary
- ensure credential anchoring waits for finalization and records block hash
- embed tx hash in QR code for verification
- expose tx link on verify page

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf2111184c832b8a1202838278e5d8