### PR TITLE
feat: persist login session

### DIFF
--- a/src/components/DidProvider.tsx
+++ b/src/components/DidProvider.tsx
@@ -1,5 +1,11 @@
 "use client";
-import { createContext, useContext, useState, ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  useState,
+  ReactNode,
+  useEffect,
+} from "react";
 
 type DidContextValue = {
   did: string | null;
@@ -9,7 +15,22 @@ type DidContextValue = {
 const DidContext = createContext<DidContextValue | undefined>(undefined);
 
 export function DidProvider({ children }: { children: ReactNode }) {
-  const [did, setDid] = useState<string | null>(null);
+  const [did, setDid] = useState<string | null>(() => {
+    if (typeof window !== "undefined") {
+      return sessionStorage.getItem("did");
+    }
+    return null;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (did) {
+      sessionStorage.setItem("did", did);
+    } else {
+      sessionStorage.removeItem("did");
+    }
+  }, [did]);
+
   return (
     <DidContext.Provider value={{ did, setDid }}>
       {children}


### PR DESCRIPTION
## Summary
- keep DID login in session storage for page reloads

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf22e0f554832bbb43d8d3e0ad53a9