### PR TITLE
Add error log debug page

### DIFF
--- a/src/app/debug/error-log/page.tsx
+++ b/src/app/debug/error-log/page.tsx
@@ -1,0 +1,34 @@
+import fs from "fs";
+import path from "path";
+
+export default function ErrorLogPage() {
+  const logPath = path.join(process.cwd(), "error.log");
+  let content: string;
+  try {
+    content = fs.readFileSync(logPath, "utf8");
+  } catch {
+    content = "No error.log found.";
+  }
+
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>Error Log</h1>
+      <p>
+        Showing contents of <code>{logPath}</code>
+      </p>
+      <pre
+        style={{
+          background: "#111",
+          color: "#eee",
+          padding: 12,
+          borderRadius: 8,
+          maxHeight: "70vh",
+          overflowY: "auto",
+          whiteSpace: "pre-wrap",
+        }}
+      >
+        {content}
+      </pre>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add /debug/error-log page to inspect `error.log`

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf26837b38832ba69776416fdb42ce