### PR TITLE
feat: connect polkadot mainnet and solana devnet

### DIFF
--- a/src/app/anchor/page.tsx
+++ b/src/app/anchor/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import type { DispatchError } from "@polkadot/types/interfaces";
 import type { AccountInfo } from "@polkadot/types/interfaces/system";
 
 /**
- * W3b Stitch — Anchor Media (Westend / Polkadot)
+ * W3b Stitch — Anchor Media (Polkadot)
  * - Client-only (safe for Vercel)
  * - Dynamic imports for chain libs
  * - Robust tx flow: Broadcast → InBlock → Finalized (nonce:-1)
@@ -13,7 +13,6 @@ import type { AccountInfo } from "@polkadot/types/interfaces/system";
  */
 
 export default function AnchorPage() {
-  const [network, setNetwork] = useState<"westend" | "polkadot">("westend");
   const [url, setUrl] = useState("");
   const [wallet, setWallet] = useState<{ address: string } | null>(null);
   const [hashHex, setHashHex] = useState("");
@@ -43,10 +42,7 @@ export default function AnchorPage() {
 
   const fileRef = useRef<HTMLInputElement | null>(null);
 
-  const wsEndpoint = useMemo(
-    () => (network === "westend" ? "wss://westend-rpc.polkadot.io" : "wss://rpc.polkadot.io"),
-    [network]
-  );
+  const wsEndpoint = "wss://rpc.polkadot.io";
 
   // ---------- utils ----------
   function toHexFromUtf8(s: string) {
@@ -134,9 +130,9 @@ export default function AnchorPage() {
 
       const accountInfo = accountInfoRaw as unknown as AccountInfo;
       const free = BigInt(accountInfo.data.free.toString());
-      const MIN = BigInt(1_000_000_000); // ~0.01 WND
-      if (network === "westend" && free < MIN) {
-        setStatus(`Not enough WND to pay fees. Free balance: ${free.toString()}`);
+      const MIN = BigInt(1_000_000_000); // ~0.01 DOT
+      if (free < MIN) {
+        setStatus(`Not enough DOT to pay fees. Free balance: ${free.toString()}`);
         return;
       }
 
@@ -206,7 +202,7 @@ export default function AnchorPage() {
     if (!extrinsicHash || !wallet) return;
     const receipt = {
       type: "w3bstitch.tdr",
-      chain: network,
+      chain: "polkadot",
       extrinsicHash,
       finalizedBlock: finalizedBlock || "(pending)",
       account: wallet.address,
@@ -228,10 +224,7 @@ export default function AnchorPage() {
   }
 
   // ---------- UI ----------
-  const subscanBase =
-    network === "westend"
-      ? "https://westend.subscan.io/extrinsic/"
-      : "https://polkadot.subscan.io/extrinsic/";
+  const subscanBase = "https://polkadot.subscan.io/extrinsic/";
 
   return (
     <div style={{ maxWidth: 720, margin: "40px auto", padding: 16 }}>
@@ -240,13 +233,11 @@ export default function AnchorPage() {
         Hash a file or URL, then anchor via <code>system.remarkWithEvent</code>.
       </p>
 
-      <label style={{ display: "block", marginBottom: 8 }}>
-        Network:&nbsp;
-        <select value={network} onChange={(e) => setNetwork(e.target.value as "westend" | "polkadot")}>
-          <option value="westend">Westend (testnet)</option>
-          <option value="polkadot">Polkadot (mainnet)</option>
-        </select>
-      </label>
+      <div style={{ display: "block", marginBottom: 8 }}>
+        <a href="/solana">
+          <button>Solana Devnet (Solflare)</button>
+        </a>
+      </div>
 
       <div style={{ display: "grid", gap: 8, margin: "12px 0" }}>
         <input

--- a/src/app/credential/page.tsx
+++ b/src/app/credential/page.tsx
@@ -61,6 +61,14 @@ export default function CredentialPage() {
   return (
     <main className="mx-auto max-w-xl p-6 space-y-6">
       <h1 className="text-2xl font-bold">Credential → QR Verification</h1>
+      <div className="flex gap-2">
+        <a href="/polkadot" className="text-indigo-600 underline text-sm">
+          Polkadot
+        </a>
+        <a href="/solana" className="text-purple-600 underline text-sm">
+          Solana Devnet
+        </a>
+      </div>
 
       <div className="space-y-2">
         <label className="block text-sm font-medium">Upload credential (PDF/Image)</label>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,7 @@ export default function Home() {
             🔗 Polkadot Connectivity
           </a>
           <a href="/solana" className="px-6 py-3 bg-purple-600 hover:bg-purple-700 text-white font-semibold rounded-xl shadow-lg transition">
-            🔥 Solana Connectivity
+            🔥 Solana Devnet (Solflare)
           </a>
           <a href="/verify" className="px-6 py-3 bg-white hover:bg-gray-200 text-black font-semibold rounded-xl shadow-lg transition">
             ✅ Try Verification

--- a/src/app/polkadot/page.tsx
+++ b/src/app/polkadot/page.tsx
@@ -11,7 +11,7 @@ export default function PolkadotConnectivity() {
     endpoint: string;
     error?: string;
   }>({
-    endpoint: "wss://westend-rpc.polkadot.io",
+    endpoint: "wss://rpc.polkadot.io",
   });
 
   useEffect(() => {
@@ -52,7 +52,7 @@ export default function PolkadotConnectivity() {
 
   return (
     <main className="mx-auto max-w-xl p-6 space-y-4">
-      <h1 className="text-2xl font-bold">Polkadot Connectivity (Westend)</h1>
+      <h1 className="text-2xl font-bold">Polkadot Connectivity (Mainnet)</h1>
       <p className="text-sm text-gray-400">
         Endpoint: <code>{info.endpoint}</code>
       </p>

--- a/src/app/verify/page.tsx
+++ b/src/app/verify/page.tsx
@@ -42,6 +42,14 @@ export default function VerifyPage() {
   return (
     <main className="mx-auto max-w-xl p-6 space-y-6">
       <h1 className="text-2xl font-bold">Verify Credential</h1>
+      <div className="flex gap-2">
+        <a href="/polkadot" className="text-indigo-600 underline text-sm">
+          Polkadot
+        </a>
+        <a href="/solana" className="text-purple-600 underline text-sm">
+          Solana Devnet
+        </a>
+      </div>
 
       <div className="space-y-1">
         <p className="text-sm">Expected hash (from QR):</p>


### PR DESCRIPTION
## Summary
- default anchor flow to Polkadot mainnet and add Solana Devnet link for Solflare
- update connectivity page to use Polkadot mainnet
- expose Polkadot and Solana links on credential and verify pages and rename home link

## Testing
- `npm test` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68bf277ec9e8832badbd485787c985e4