### PR TITLE
chore: default credential anchoring to solana devnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
  for a live connectivity check. https://w3bstitch-web-git-feature-cred-20136e-rocketjays-cmyks-projects.vercel.app
 <img width="828" height="260" alt="Screenshot 2025-08-30 090650" src="https://github.com/user-attachments/assets/015fcb4f-90a7-4d3d-b251-a8d3360246e8" />
 
+### Environment
+
+The credential anchoring API reads `ANCHOR_ENDPOINT` to know where to submit hashes.
+If unset, it defaults to the Solana devnet endpoint `https://api.devnet.solana.com`.
+
 ## 📜 License
 Apache-2.0
-"@ | Out-File -Encoding utf8 -FilePath README.md

--- a/env.example
+++ b/env.example
@@ -1,0 +1,1 @@
+ANCHOR_ENDPOINT=https://api.devnet.solana.com

--- a/src/app/api/credential/route.ts
+++ b/src/app/api/credential/route.ts
@@ -21,7 +21,8 @@ export async function POST(req: NextRequest): Promise<NextResponse<AnchorRespons
       return NextResponse.json({ ok: false, error: "hash required" }, { status: 400 });
     }
 
-    const endpoint = process.env.ANCHOR_ENDPOINT;
+    // Default to Solana devnet anchoring if no endpoint is provided.
+    const endpoint = process.env.ANCHOR_ENDPOINT ?? "https://api.devnet.solana.com";
     if (endpoint) {
       const r = await fetch(endpoint, {
         method: "POST",


### PR DESCRIPTION
## Summary
- default credential API to Solana devnet when no anchor endpoint is provided
- document anchoring configuration and add env example

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf2a8ae4b4832ba16a112e72965dfb