### PR TITLE
Add Vercel Speed Insights integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@polkadot/extension-dapp": "^0.61.7",
     "@polkadot/util": "^13.5.6",
     "@polkadot/util-crypto": "^13.5.6",
+    "@vercel/speed-insights": "^1",
     "next": "15.5.2",
     "qrcode": "^1.5.4",
     "react": "19.1.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import BackButton from "../components/BackButton";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,6 +31,7 @@ export default function RootLayout({
       >
         <BackButton />
         {children}
+        <SpeedInsights />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- add `@vercel/speed-insights` dependency
- load Vercel Speed Insights in root layout

## Testing
- `npm test` *(fails: command not found)*
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf344d4cf4832ba5b6c42ef882937a