### PR TITLE
feat: add solflare login support

### DIFF
--- a/src/components/ChainIndicator.tsx
+++ b/src/components/ChainIndicator.tsx
@@ -4,6 +4,9 @@ import { useDid } from "./DidProvider";
 
 function networkFromDid(did: string): string {
   const parts = did.split(":");
+  if (parts[1] === "solana") {
+    return "solana";
+  }
   return parts[2] || "";
 }
 


### PR DESCRIPTION
## Summary
- add Solflare wallet connectivity with slot and version info
- show Solana connection in ChainIndicator

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf49aa9cd4832ba2f0e50c8edf9020