### PR TITLE
feat: allow custom solana rpc

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -89,7 +89,10 @@ export default function LoginPage() {
           throw new Error("Failed to retrieve public key");
         }
         const { Connection } = await import("@solana/web3.js");
-        const connection = new Connection("https://api.mainnet-beta.solana.com");
+        const rpcUrl =
+          process.env.NEXT_PUBLIC_SOLANA_RPC ||
+          "https://api.mainnet-beta.solana.com";
+        const connection = new Connection(rpcUrl);
         const [slot, versionInfo] = await Promise.all([
           connection.getSlot(),
           connection.getVersion(),


### PR DESCRIPTION
## Summary
- allow configuring Solana RPC via env

## Testing
- `npm test` *(fails: Missing script: "test"*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bf4b0b8218832b840ab7eae9ccf292