### PR TITLE
feat: persist solflare wallet across pages

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import BackButton from "../components/BackButton";
 import { DidProvider } from "../components/DidProvider";
+import { WalletProvider } from "../components/WalletProvider";
 
 export const metadata: Metadata = {
   title: "W3b Stitch- Trust Engine",
@@ -17,8 +18,10 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <DidProvider>
-          <BackButton />
-          {children}
+          <WalletProvider>
+            <BackButton />
+            {children}
+          </WalletProvider>
         </DidProvider>
       </body>
     </html>

--- a/src/components/ChainIndicator.tsx
+++ b/src/components/ChainIndicator.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useDid } from "./DidProvider";
+import { useWallet } from "./WalletProvider";
 
 function networkFromDid(did: string): string {
   const parts = did.split(":");
@@ -11,11 +12,25 @@ function networkFromDid(did: string): string {
 }
 
 export default function ChainIndicator() {
-  const { did } = useDid();
+  const { did, setDid } = useDid();
+  const { disconnectSolana } = useWallet();
   if (!did) {
     return <span className="text-sm text-red-500">Not logged in</span>;
   }
 
   const network = networkFromDid(did);
-  return <span className="text-sm">Connected: {network}</span>;
+
+  function logout() {
+    disconnectSolana();
+    setDid(null);
+  }
+
+  return (
+    <span className="text-sm flex items-center gap-2">
+      Connected: {network}
+      <button onClick={logout} className="underline">
+        Logout
+      </button>
+    </span>
+  );
 }

--- a/src/components/WalletProvider.tsx
+++ b/src/components/WalletProvider.tsx
@@ -1,0 +1,86 @@
+"use client";
+import { createContext, useContext, useEffect, useState, ReactNode } from "react";
+
+interface SolflareWallet {
+  isSolflare?: boolean;
+  connect: (args?: { onlyIfTrusted?: boolean }) => Promise<{ publicKey: { toString(): string } } | void>;
+  disconnect?: () => Promise<void> | void;
+  publicKey?: { toString(): string };
+}
+
+interface SolflareWindow extends Window {
+  solflare?: SolflareWallet;
+  solana?: SolflareWallet;
+}
+
+type WalletContextValue = {
+  solanaAddress: string | null;
+  connectSolana: () => Promise<string>;
+  disconnectSolana: () => void;
+};
+
+const WalletContext = createContext<WalletContextValue | undefined>(undefined);
+
+export function WalletProvider({ children }: { children: ReactNode }) {
+  const [solanaAddress, setSolanaAddress] = useState<string | null>(() => {
+    if (typeof window !== "undefined") {
+      return sessionStorage.getItem("solanaAddress");
+    }
+    return null;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!solanaAddress) return;
+    const provider =
+      (window as SolflareWindow).solflare ?? (window as SolflareWindow).solana;
+    if (!provider) {
+      setSolanaAddress(null);
+      sessionStorage.removeItem("solanaAddress");
+      return;
+    }
+    provider.connect({ onlyIfTrusted: true }).catch(() => {
+      setSolanaAddress(null);
+      sessionStorage.removeItem("solanaAddress");
+    });
+  }, []);
+
+  async function connectSolana() {
+    const provider =
+      (window as SolflareWindow).solflare ?? (window as SolflareWindow).solana;
+    if (!provider) throw new Error("No Solflare wallet found");
+    await provider.connect();
+    const pubkey = provider.publicKey?.toString();
+    if (!pubkey) throw new Error("Failed to retrieve public key");
+    setSolanaAddress(pubkey);
+    sessionStorage.setItem("solanaAddress", pubkey);
+    return pubkey;
+  }
+
+  function disconnectSolana() {
+    const provider =
+      (window as SolflareWindow).solflare ?? (window as SolflareWindow).solana;
+    try {
+      provider?.disconnect?.();
+    } catch {
+      /* ignore */
+    }
+    setSolanaAddress(null);
+    sessionStorage.removeItem("solanaAddress");
+  }
+
+  return (
+    <WalletContext.Provider
+      value={{ solanaAddress, connectSolana, disconnectSolana }}
+    >
+      {children}
+    </WalletContext.Provider>
+  );
+}
+
+export function useWallet() {
+  const ctx = useContext(WalletContext);
+  if (!ctx) throw new Error("useWallet must be used within WalletProvider");
+  return ctx;
+}
+


### PR DESCRIPTION
## Summary
- add WalletProvider to manage Solflare connection and logout
- keep wallet state across pages and ensure Solana login opens extension
- auto-connect wallet on credential anchoring page

## Testing
- `npm run lint` *(fails: interactive configuration prompt)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c4b04f73d4832b8021d1cdf5c8e9e9