### PR TITLE
Add Solana configuration constants

### DIFF
--- a/config/solana.ts
+++ b/config/solana.ts
@@ -1,0 +1,2 @@
+export const SOLANA_RPC_ENDPOINT = process.env.NEXT_PUBLIC_SOLANA_RPC || 'https://api.devnet.solana.com';
+export const SOLANA_COMMITMENT = 'confirmed';


### PR DESCRIPTION
## Summary
- add Solana config with RPC endpoint fallback and default commitment

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c54e175e38832b933e8edd00837bb3