### PR TITLE
feat: add Solana providers component

### DIFF
--- a/config/solana.ts
+++ b/config/solana.ts
@@ -1,0 +1,5 @@
+export const SOLANA_RPC_ENDPOINT =
+  process.env.NEXT_PUBLIC_SOLANA_RPC ?? "https://api.devnet.solana.com";
+
+export const SOLANA_COMMITMENT =
+  process.env.NEXT_PUBLIC_SOLANA_COMMITMENT ?? "confirmed";

--- a/src/components/SolanaProviders.tsx
+++ b/src/components/SolanaProviders.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useMemo } from "react";
+// eslint-disable-next-line import/no-unresolved
+import {
+  ConnectionProvider,
+  WalletProvider,
+} from "@solana/wallet-adapter-react";
+// eslint-disable-next-line import/no-unresolved
+import { WalletModalProvider } from "@solana/wallet-adapter-react-ui";
+// eslint-disable-next-line import/no-unresolved
+import { SolflareWalletAdapter } from "@solana/wallet-adapter-solflare";
+import {
+  SOLANA_RPC_ENDPOINT,
+  SOLANA_COMMITMENT,
+} from "config/solana";
+
+// eslint-disable-next-line import/no-unresolved
+import "@solana/wallet-adapter-react-ui/styles.css";
+
+export function SolanaProviders({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const wallets = useMemo(() => [new SolflareWalletAdapter()], []);
+
+  return (
+    <ConnectionProvider
+      endpoint={SOLANA_RPC_ENDPOINT}
+      config={{ commitment: SOLANA_COMMITMENT }}
+    >
+      <WalletProvider wallets={wallets} autoConnect>
+        <WalletModalProvider>{children}</WalletModalProvider>
+      </WalletProvider>
+    </ConnectionProvider>
+  );
+}

--- a/src/types/solana-wallet-adapter.d.ts
+++ b/src/types/solana-wallet-adapter.d.ts
@@ -1,8 +1,23 @@
 declare module '@solana/wallet-adapter-react' {
   import type { FC, ReactNode } from 'react';
-  export const ConnectionProvider: FC<{ endpoint: string; children: ReactNode }>;
-  export const WalletProvider: FC<{ wallets: any[]; children: ReactNode; autoConnect?: boolean }>;
+  export const ConnectionProvider: FC<{
+    endpoint: string;
+    children: ReactNode;
+    config?: { commitment?: string };
+  }>;
+  export const WalletProvider: FC<{
+    wallets: any[];
+    children: ReactNode;
+    autoConnect?: boolean;
+  }>;
 }
+
+declare module '@solana/wallet-adapter-react-ui' {
+  import type { FC, ReactNode } from 'react';
+  export const WalletModalProvider: FC<{ children: ReactNode }>;
+}
+
+declare module '@solana/wallet-adapter-react-ui/styles.css';
 
 declare module '@solana/wallet-adapter-solflare' {
   export class SolflareWalletAdapter {


### PR DESCRIPTION
## Summary
- add SolanaProviders wrapper for ConnectionProvider, WalletProvider and WalletModalProvider
- configure Solana RPC endpoint and commitment constants
- extend wallet adapter type declarations for modal provider support

## Testing
- `npm run lint` (fails: next not found)
- `npm install` (fails: 403 Forbidden)
- `npm run typecheck` (fails: cannot find modules)


------
https://chatgpt.com/codex/tasks/task_e_68c54e31d4e4832bac9a1f64e4afc1d4