### PR TITLE
chore: remove Polkadot reference

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,8 +13,7 @@ export default function Home() {
 
         <p className="mb-10 text-lg text-gray-300 max-w-2xl mx-auto">
           A decentralized trust engine for verifying media, credentials, and
-          identities. Built on <span className="font-semibold">Polkadot</span>{" "}
-          for security and interoperability.
+          identities.
         </p>
 
         <div className="flex items-center justify-center gap-4 flex-wrap">


### PR DESCRIPTION
## Summary
- drop "Built on Polkadot for security and interoperability" from the homepage hero paragraph

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run typecheck` *(fails: Expected corresponding JSX closing tag for 'html')*
- `npm run build` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5501c6ecc832bb2687999f6f4bba7