### PR TITLE
fix: add Next.js dependencies and layout markup

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
   "dependencies": {
     "@polkadot/api": "^16.4.6",
     "@polkadot/util-crypto": "^13.5.6",
-
     "qrcode": "^1.5.4",
-    "@solana/web3.js": "^1.95.4"
+    "@solana/web3.js": "^1.95.4",
+    "next": "^14.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.12",
@@ -25,6 +27,7 @@
     "typescript": "^5.9.2",
     "@types/qrcode": "^1.5.5",
     "tailwindcss": "^4.1.12",
-    "@types/react": "^19.1.12"
+    "@types/react": "^19.1.12",
+    "@types/node": "^20.11.30"
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,5 @@
 import type { Metadata } from "next";
 import "./globals.css";
-import BackButton from "../components/BackButton";
-
-
 export const metadata: Metadata = {
   title: "W3b Stitch- Trust Engine",
   description: "Decentralized trust engine",
@@ -15,7 +12,8 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-
+      <body>
+        {children}
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- add Next.js, React, and type definitions to package.json
- render children within a proper body tag in root layout

## Testing
- `npm run lint` (fails: sh: next: not found)
- `npm run typecheck` (fails: multiple module resolution errors)


------
https://chatgpt.com/codex/tasks/task_e_68c5517a3e68832bbd25deaf52dc176b