### PR TITLE
Show QR code without wallet confirmation

### DIFF
--- a/src/app/credential/page.tsx
+++ b/src/app/credential/page.tsx
@@ -53,8 +53,20 @@ export default function CredentialPage() {
     const didAddress = parts[3];
     setLoading(true);
     setError("");
-    setStatus("Connecting wallet…");
     try {
+      // Generate QR code ahead of wallet interaction so it is available even
+      // if the user never confirms the transaction in their wallet.
+      const QRCode = (await import("qrcode")).default;
+      const verifyUrl = `${window.location.origin}/verify?did=${encodeURIComponent(
+        did,
+      )}&hash=${encodeURIComponent(hash)}`;
+      const png = await QRCode.toDataURL(verifyUrl, {
+        margin: 1,
+        width: 280,
+      });
+      setQr(png);
+
+      setStatus("Connecting wallet…");
       const [
         { web3Enable, web3Accounts, web3FromAddress },
         { ApiPromise, WsProvider },
@@ -105,14 +117,6 @@ export default function CredentialPage() {
                 txHash: txh,
                 explorer: `https://westend.subscan.io/extrinsic/${txh}`,
               });
-
-              const QRCode = (await import("qrcode")).default;
-              const verifyUrl = `${window.location.origin}/verify?did=${encodeURIComponent(did)}&hash=${encodeURIComponent(hash)}`;
-              const png = await QRCode.toDataURL(verifyUrl, {
-                margin: 1,
-                width: 280,
-              });
-              setQr(png);
             }
             if (status.isFinalized) {
               setStatus("Finalized");


### PR DESCRIPTION
## Summary
- Generate credential verification QR code before any wallet interaction
- Remove QR creation from transaction callback so QR displays even if the wallet isn't confirmed

## Testing
- `npx prettier src/app/credential/page.tsx -w`
- `npm run typecheck` *(fails: Expected corresponding JSX closing tag for 'html')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c55315a348832bb6c60d54a5c62783