### PR TITLE
fix: add missing Next.js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "@polkadot/util-crypto": "^13.5.6",
 
     "qrcode": "^1.5.4",
-    "@solana/web3.js": "^1.95.4"
+    "@solana/web3.js": "^1.95.4",
+    "next": "^14.2.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.12",


### PR DESCRIPTION
## Summary
- add `next`, `react`, and `react-dom` dependencies so Vercel can detect Next.js

## Testing
- `npm install --no-package-lock` *(fails: 403 Forbidden to registry)*
- `npm run build` *(fails: next: not found)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c55460e1c8832b897430854c87357b